### PR TITLE
Remove Hangfire.Core's own dependencies from nuspec

### DIFF
--- a/Hangfire.MemoryStorage.nuspec
+++ b/Hangfire.MemoryStorage.nuspec
@@ -14,8 +14,6 @@
     <tags>Hangfire Storage</tags>
     <dependencies>
       <dependency id="Hangfire.Core" version="1.4.3" />
-      <dependency id="Newtonsoft.Json" version="6.0.8" />
-      <dependency id="Owin" version="1.0.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
I've removed `Newtonsoft.Json` and `Owin` dependencies from the `Hangfire.MemoryStorage.nuspec` file. These dependencies aren't needed for Hangfire.MemoryStorage, because only Hangfire.Core requires them.