### PR TITLE
When a 'Created' job history entry already exists, then don't add ano…

### DIFF
--- a/src/Hangfire.MemoryStorage/Dto/JobDto.cs
+++ b/src/Hangfire.MemoryStorage/Dto/JobDto.cs
@@ -1,3 +1,4 @@
+using Hangfire.MemoryStorage.Utilities;
 ﻿using Hangfire.Storage.Monitoring;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ namespace Hangfire.MemoryStorage.Dto
     {
         public JobDto()
         {
-            History = new List<StateHistoryDto>();
+            History = new StateHistoryList();
             Parameters = new List<JobParameterDto>();
         }
 

--- a/src/Hangfire.MemoryStorage/Utilities/StateHistoryList.cs
+++ b/src/Hangfire.MemoryStorage/Utilities/StateHistoryList.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Hangfire.Storage.Monitoring;
+
+namespace Hangfire.MemoryStorage.Utilities
+{
+    public class StateHistoryList : IList<StateHistoryDto>
+    {
+        private readonly IList<StateHistoryDto> _list = new List<StateHistoryDto>();
+
+        public IEnumerator<StateHistoryDto> GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(StateHistoryDto item)
+        {
+            if (_list.Any(t => t.StateName == "Created"))
+            {
+                return;
+            }
+
+            _list.Add(item);
+        }
+
+        public void Clear()
+        {
+            _list.Clear();
+        }
+
+        public bool Contains(StateHistoryDto item)
+        {
+            return _list.Contains(item);
+        }
+
+        public void CopyTo(StateHistoryDto[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(StateHistoryDto item)
+        {
+            return _list.Remove(item);
+        }
+
+        public int Count
+        {
+            get { return _list.Count; }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return _list.IsReadOnly; }
+        }
+
+        public int IndexOf(StateHistoryDto item)
+        {
+            return _list.IndexOf(item);
+        }
+
+        public void Insert(int index, StateHistoryDto item)
+        {
+            _list.Insert(index, item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+
+        public StateHistoryDto this[int index]
+        {
+            get { return _list[index]; }
+            set { _list[index] = value; }
+        }
+    }
+}


### PR DESCRIPTION
…ther one.

Because of the way that Hangfire's `JobDetailsPage.cshtml` is written (Lines 19-23 https://github.com/HangfireIO/Hangfire/blob/129707d66fde24dc6379fb9d6b15fa0b8ca48605/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml), it will always add a _Created_ state history entry every time the page is executed. Since jobs are persisted in memory, this entry gets created every time the page is refreshed or navigated to.

This pull request is just a change to make the `History` collection a custom list type that discards adding any new state history with the name _Created_ to prevent the duplicates from being added.