### PR TITLE
Fixed a leak of Locks ConcurrentDictionary

### DIFF
--- a/src/Hangfire.MemoryStorage/Utilities/LocalLock.cs
+++ b/src/Hangfire.MemoryStorage/Utilities/LocalLock.cs
@@ -8,10 +8,12 @@ namespace Hangfire.MemoryStorage.Utilities
     {
         private static readonly ConcurrentDictionary<string, object> Locks = new ConcurrentDictionary<string, object>();
         private readonly object _lock;
+        private readonly string _resource;
 
         private LocalLock(string resource, TimeSpan timeout)
         {
             _lock = Locks.GetOrAdd(resource, new object());
+            _resource = resource;
 
             bool hasEntered = Monitor.TryEnter(_lock, timeout);
             if (!hasEntered)
@@ -23,6 +25,8 @@ namespace Hangfire.MemoryStorage.Utilities
         public void Dispose()
         {
             Monitor.Exit(_lock);
+
+            Locks.TryRemove(_resource, out object value);
         }
 
         public static IDisposable AcquireLock(string resource, TimeSpan timeout)


### PR DESCRIPTION
We have long-running WebAPI services, which use HangFire memory storage to dispatch background tasks for our game servers.
These tasks are dispatched for every transaction, and after 19-day of execution, we did a dump of the process. It showed that we accumulated 2.4GB in the Locks ConcurrentDictionary. In that time frame, we had 8 million transactions.

Seems that these Locks entries are not removed, and each entry is a BackgroundJob Id based, which is unique, so it will always keep the old entries, whilst accumulating new ones.

