### PR TITLE
Method "UseMemoryStorage" return value is changed from "MemoryStorage" to "IGlobalConfiguration<MemoryStorage>"

### DIFF
--- a/src/Hangfire.MemoryStorage/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.MemoryStorage/GlobalConfigurationExtensions.cs
@@ -4,31 +4,27 @@ namespace Hangfire.MemoryStorage
 {
     public static class GlobalConfigurationExtensions
     {
-        public static MemoryStorage UseMemoryStorage(this IGlobalConfiguration configuration)
+        public static IGlobalConfiguration<MemoryStorage> UseMemoryStorage(this IGlobalConfiguration configuration)
         {
             var storageOptions = new MemoryStorageOptions();
 
             return configuration.UseMemoryStorage(storageOptions);
         }
 
-        public static MemoryStorage UseMemoryStorage(this IGlobalConfiguration configuration,
+        public static IGlobalConfiguration<MemoryStorage> UseMemoryStorage(this IGlobalConfiguration configuration,
             MemoryStorageOptions storageOptions)
         {
             var storage = new MemoryStorage(storageOptions);
 
-            configuration.UseStorage(storage);
-
-            return storage;
+            return configuration.UseStorage(storage);
         }
 
-        public static MemoryStorage UseMemoryStorage(this IGlobalConfiguration configuration,
+        public static IGlobalConfiguration<MemoryStorage> UseMemoryStorage(this IGlobalConfiguration configuration,
             MemoryStorageOptions storageOptions, Data data)
         {
             var storage = new MemoryStorage(storageOptions, data);
 
-            configuration.UseStorage(storage);
-
-            return storage;
+            return configuration.UseStorage(storage);
         }
     }
 }


### PR DESCRIPTION
Method "UseMemoryStorage" return value is changed from "MemoryStorage" to "IGlobalConfiguration<MemoryStorage>"