### PR TITLE
Updating Hangfire.Core from 1.6.13 to 1.7.9 and updated affected obsolete methods.

### DIFF
--- a/src/Hangfire.MemoryStorage/Hangfire.MemoryStorage.csproj
+++ b/src/Hangfire.MemoryStorage/Hangfire.MemoryStorage.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.6.13" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.9" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
@@ -57,7 +57,7 @@ namespace Hangfire.MemoryStorage
             Guard.ArgumentNotNull(job, "job");
             Guard.ArgumentNotNull(parameters, "parameters");
 
-            var invocationData = InvocationData.Serialize(job);
+            var invocationData = InvocationData.SerializeJob(job);
 
             var jobData = new JobDto
             {
@@ -188,7 +188,7 @@ namespace Hangfire.MemoryStorage
 
             try
             {
-                job = invocationData.Deserialize();
+                job = invocationData.DeserializeJob();
             }
             catch (JobLoadException ex)
             {

--- a/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
@@ -48,7 +48,7 @@ namespace Hangfire.MemoryStorage
             };
 
             server.LastHeartbeat = DateTime.UtcNow;
-            server.Data = JobHelper.ToJson(data);
+            server.Data = SerializationHelper.Serialize(data, null, SerializationOption.User);
         }
 
         public override string CreateExpiredJob(Job job, IDictionary<string, string> parameters, DateTime createdAt,
@@ -62,7 +62,7 @@ namespace Hangfire.MemoryStorage
             var jobData = new JobDto
             {
                 Id = Guid.NewGuid().ToString(),
-                InvocationData = JobHelper.ToJson(invocationData),
+                InvocationData = SerializationHelper.Serialize(invocationData, null, SerializationOption.User),
                 Arguments = invocationData.Arguments,
                 CreatedAt = createdAt,
                 ExpireAt = createdAt.Add(expireIn)

--- a/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageConnection.cs
@@ -179,7 +179,7 @@ namespace Hangfire.MemoryStorage
                 return null;
             }
 
-            var invocationData = JobHelper.FromJson<InvocationData>(jobData.InvocationData);
+            var invocationData = SerializationHelper.Deserialize<InvocationData>(jobData.InvocationData, SerializationOption.User);
 
             invocationData.Arguments = jobData.Arguments;
 
@@ -250,7 +250,7 @@ namespace Hangfire.MemoryStorage
                 Name = jobData.State.Name,
                 Reason = jobData.State.Reason,
                 Data = new Dictionary<string, string>(
-                    JobHelper.FromJson<Dictionary<string, string>>(jobData.State.Data),
+                    SerializationHelper.Deserialize<Dictionary<string, string>>(jobData.State.Data, SerializationOption.User),
                     StringComparer.OrdinalIgnoreCase)
             };
         }

--- a/src/Hangfire.MemoryStorage/MemoryStorageMonitoringApi.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageMonitoringApi.cs
@@ -389,7 +389,7 @@ namespace Hangfire.MemoryStorage
 
             try
             {
-                return data.Deserialize();
+                return data.DeserializeJob();
             }
             catch (JobLoadException)
             {

--- a/src/Hangfire.MemoryStorage/MemoryStorageMonitoringApi.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageMonitoringApi.cs
@@ -212,7 +212,7 @@ namespace Hangfire.MemoryStorage
 
             var query =
                 from server in servers
-                let serverData = JobHelper.FromJson<ServerData>(server.Data)
+                let serverData = SerializationHelper.Deserialize<ServerData>(server.Data, SerializationOption.User)
                 select new ServerDto
                 {
                     Name = server.Id,
@@ -384,7 +384,7 @@ namespace Hangfire.MemoryStorage
 
         private static Job DeserializeJob(string invocationData, string arguments)
         {
-            var data = JobHelper.FromJson<InvocationData>(invocationData);
+            var data = SerializationHelper.Deserialize<InvocationData>(invocationData, SerializationOption.User);
             data.Arguments = arguments;
 
             try
@@ -402,7 +402,7 @@ namespace Hangfire.MemoryStorage
             Func<JsonJob, Job, Dictionary<string, string>, TDto> selector)
         {
             var result = from job in jobs
-                let deserializedData = JobHelper.FromJson<Dictionary<string, string>>(job.StateData)
+                let deserializedData = SerializationHelper.Deserialize<Dictionary<string, string>>(job.StateData, SerializationOption.User)
                 let stateData = deserializedData != null
                     ? new Dictionary<string, string>(deserializedData, StringComparer.OrdinalIgnoreCase)
                     : null

--- a/src/Hangfire.MemoryStorage/MemoryStorageWriteOnlyTransaction.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorageWriteOnlyTransaction.cs
@@ -49,7 +49,7 @@ namespace Hangfire.MemoryStorage
                     Name = state.Name,
                     Reason = state.Reason,
                     CreatedAt = createdAt,
-                    Data = JobHelper.ToJson(serializedStateData)
+                    Data = SerializationHelper.Serialize(serializedStateData, null, SerializationOption.User)
                 };
 
                 var stateHistory = new StateHistoryDto
@@ -294,7 +294,7 @@ namespace Hangfire.MemoryStorage
                     Name = state.Name,
                     Reason = state.Reason,
                     CreatedAt = createdAt,
-                    Data = JobHelper.ToJson(serializedStateData)
+                    Data = SerializationHelper.Serialize(serializedStateData, null, SerializationOption.User)
                 };
 
                 var stateHistory = new StateHistoryDto


### PR DESCRIPTION
The choice of arguments for the obsolete method replacements was taken directly from [https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.Core/Storage/InvocationData.cs](url) and [https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.Core/Common/JobHelper.cs](url)