### PR TITLE
Dont use static fields to keep track of locks

### DIFF
--- a/src/Hangfire.MemoryStorage/MemoryStorage.cs
+++ b/src/Hangfire.MemoryStorage/MemoryStorage.cs
@@ -9,6 +9,9 @@ namespace Hangfire.MemoryStorage
     {
         private readonly MemoryStorageOptions _options;
 
+        private readonly object _connectionLock = new object();
+        private MemoryStorageConnection _connection;
+
         public Data Data { get; }
 
         public MemoryStorage() : this(new MemoryStorageOptions(), new Data())
@@ -27,7 +30,12 @@ namespace Hangfire.MemoryStorage
 
         public override IStorageConnection GetConnection()
         {
-            return new MemoryStorageConnection(Data, _options.FetchNextJobTimeout);
+            lock (_connectionLock)
+            {
+                if (_connection == null)
+                    _connection = new MemoryStorageConnection(Data, _options.FetchNextJobTimeout);
+            }
+            return _connection;
         }
 
         public override IMonitoringApi GetMonitoringApi()


### PR DESCRIPTION
This is to increase separation between multiple instances of the Memory Storage during Unit Tests which execute in parallel.